### PR TITLE
Added return of p_trampoline if hook was found

### DIFF
--- a/src/TrampHook.cpp
+++ b/src/TrampHook.cpp
@@ -27,8 +27,9 @@ void *TrampHook::hook(void *p_target, void *p_detour)
         return nullptr;
 
     /* Check that the function isn't already hooked */
-    if (hooked_functions.find(reinterpret_cast<std::uintptr_t>(p_target)) != hooked_functions.end())
-        return nullptr;
+    auto it = hooked_functions.find((uintptr_t)p_target);
+    if (it != hooked_functions.end())
+        return it->second.p_trampoline;
 
     Hook hook;
     uint8_t total_size_to_overwrite{};

--- a/src/TrampHook.cpp
+++ b/src/TrampHook.cpp
@@ -27,8 +27,7 @@ void *TrampHook::hook(void *p_target, void *p_detour)
         return nullptr;
 
     /* Check that the function isn't already hooked */
-    auto it = hooked_functions.find((uintptr_t)p_target);
-    if (it != hooked_functions.end())
+    if (auto it{hooked_functions.find(reinterpret_cast<std::uintptr_t>(p_target))}; it != hooked_functions.end())
         return it->second.p_trampoline;
 
     Hook hook;


### PR DESCRIPTION
The example in readme shows that you can get the trampoline pointer by calling the hook function after it has already been hooked. This change allows that behavior.